### PR TITLE
add new qwen moe

### DIFF
--- a/containerfiles/Containerfile-qwen3-30b-a3b-instruct-2507
+++ b/containerfiles/Containerfile-qwen3-30b-a3b-instruct-2507
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE_NAME
+ARG MODEL_SOURCE_NAME
+FROM ${BASE_IMAGE_NAME}
+
+ARG MODEL_SOURCE_NAME
+
+# Copy the entire /models directory from the model source
+# into the final application image at /mnt/models.
+COPY --from=${MODEL_SOURCE_NAME} /models /mnt/models
+
+# This is a sanity check for OpenShift's random user ID.
+USER root
+RUN chmod -R a+rX /mnt/models
+USER 1001
+
+# Optional: Add labels to describe your new all-in-one image
+LABEL maintainer="Kush Gupta"
+LABEL description="Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf from Unsloth"

--- a/k8s/lightspeed/overlays/qwen3-30b-a3b-instruct-2507/README.md
+++ b/k8s/lightspeed/overlays/qwen3-30b-a3b-instruct-2507/README.md
@@ -1,0 +1,68 @@
+# OpenShift Lightspeed with qwen3-30b-a3b-instruct-2507
+
+This overlay configures OpenShift Lightspeed to use the qwen3-30b-a3b-instruct-2507 model deployed in the `ramalama` namespace.
+
+## Prerequisites
+
+Ensure you have the qwen3-30b-a3b-instruct-2507 model running:
+```bash
+oc get pods -l model=qwen3-30b-a3b-instruct-2507 -n ramalama
+```
+
+If not deployed, deploy it first:
+```bash
+oc apply -f ../../models/ramalama-namespace.yaml
+oc apply -k ../../models/qwen3-30b-a3b-instruct-2507
+```
+
+## Deployment
+
+Due to the timing dependency between operator installation and CRD creation, deployment requires two steps:
+
+### Step 1: Install the OpenShift Lightspeed Operator
+```bash
+oc apply -k ../../base/operator-only
+```
+
+Wait for the operator to be ready (this creates the required CRDs):
+```bash
+oc wait --for=condition=Ready pod -l app.kubernetes.io/name=lightspeed-operator -n openshift-lightspeed --timeout=300s
+```
+
+### Step 2: Apply the Complete Configuration
+```bash
+oc apply -k .
+```
+
+## Verification
+
+Check that all components are running:
+```bash
+# Check operator
+oc get pods -l app.kubernetes.io/name=lightspeed-operator -n openshift-lightspeed
+
+# Check lightspeed components
+oc get pods -l app.kubernetes.io/name=lightspeed-app-server -n openshift-lightspeed
+
+# Check OLS configuration
+oc get olsconfig cluster -n openshift-lightspeed
+```
+
+## Usage
+
+1. Access the OpenShift web console
+2. Look for the Lightspeed assistant icon in the navigation
+3. Start asking questions about your cluster!
+
+Example questions:
+- "How do I create a deployment?"
+- "Show me pods that are not running"
+- "Generate a service YAML for my application"
+
+## Cleanup
+
+To remove the deployment:
+```bash
+oc delete -k .
+oc delete -k ../../base/operator-only
+```

--- a/k8s/lightspeed/overlays/qwen3-30b-a3b-instruct-2507/kustomization.yaml
+++ b/k8s/lightspeed/overlays/qwen3-30b-a3b-instruct-2507/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: openshift-lightspeed-qwen3-30b-a3b-instruct-2507
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+
+resources:
+  - ../../base/operator-only
+  - olsconfig.yaml
+
+patches:
+  - target:
+      kind: Secret
+      name: credentials
+    patch: |-
+      - op: add
+        path: /metadata/labels/model
+        value: qwen3-30b-a3b-instruct-2507
+      - op: add
+        path: /metadata/labels/environment
+        value: qwen3-30b-a3b-instruct-2507
+  - target:
+      kind: Subscription
+      name: lightspeed-operator
+    patch: |-
+      - op: add
+        path: /metadata/labels/model
+        value: qwen3-30b-a3b-instruct-2507
+      - op: add
+        path: /metadata/labels/environment
+        value: qwen3-30b-a3b-instruct-2507 

--- a/k8s/lightspeed/overlays/qwen3-30b-a3b-instruct-2507/olsconfig.yaml
+++ b/k8s/lightspeed/overlays/qwen3-30b-a3b-instruct-2507/olsconfig.yaml
@@ -1,0 +1,44 @@
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  namespace: openshift-lightspeed
+  labels:
+    app.kubernetes.io/created-by: lightspeed-operator
+    app.kubernetes.io/instance: olsconfig-sample
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: olsconfig
+    app.kubernetes.io/part-of: lightspeed-operator
+    model: qwen3-30b-a3b-instruct-2507
+    environment: qwen3-30b-a3b-instruct-2507
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  llm:
+    providers:
+      - credentialsSecretRef:
+          name: credentials
+        models:
+          - name: default
+        name: ramalama
+        type: openai
+        url: http://qwen3-30b-a3b-instruct-2507-ramalama-service.ramalama.svc.cluster.local:8080/v1
+  ols:
+    conversationCache:
+      postgres:
+        credentialsSecret: lightspeed-postgres-secret
+        dbName: postgres
+        maxConnections: 2000
+        sharedBuffers: 256MB
+        user: postgres
+      type: postgres
+    defaultModel: default
+    defaultProvider: ramalama
+    deployment:
+      console:
+        replicas: 1
+      replicas: 1
+    introspectionEnabled: true
+    logLevel: INFO
+  olsDataCollector:
+    logLevel: INFO

--- a/k8s/models/qwen3-30b-a3b-instruct-2507/kustomization.yaml
+++ b/k8s/models/qwen3-30b-a3b-instruct-2507/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: ramalama-qwen3-30b-a3b-instruct-2507
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+
+resources:
+- ../base-model
+
+namePrefix: "qwen3-30b-a3b-instruct-2507-"
+
+commonLabels:
+  app.kubernetes.io/instance: "qwen3-30b-a3b-instruct-2507"
+  model: "qwen3-30b-a3b-instruct-2507"
+
+configMapGenerator:
+- name: model-config
+  behavior: replace
+  literals:
+  - MODEL_NAME=qwen3-30b-a3b-instruct-2507
+  - MODEL_FILE=/mnt/models/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf
+  - ALIAS=qwen3-30b-a3b-instruct-2507-model
+- name: ramalama-config
+  behavior: merge
+  literals:
+  - CTX_SIZE=16384
+  - THREADS=14
+  - TEMP=0.7
+  - TOP_K=20
+  - TOP_P=0.8
+  - CACHE_REUSE=256
+
+images:
+- name: MODEL_IMAGE
+  newName: "ghcr.io/kush-gupt/qwen3-30b-a3b-instruct-2507-ramalama"
+  newTag: latest 

--- a/models/models.yaml
+++ b/models/models.yaml
@@ -59,6 +59,25 @@ models:
         memory: "16Gi"
         cpu: "4"
 
+  qwen3-30b-a3b-instruct-2507:
+    name: "Qwen 3 30B A3B Instruct 2507"
+    description: "All-in-one Ramalama server with embedded Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf Unsloth model."
+    model_source: "qwen3-30b-a3b-instruct-2507-source"
+    model_gguf_url: "hf://unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf"
+    model_file: "/mnt/models/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf"
+    maintainer: "Kush Gupta"
+    parameters:
+      ctx_size: 20048
+      threads: 14
+      temp: 0.7
+      top_k: 20
+      top_p: 0.8
+      cache_reuse: 256
+    resources:
+      requests:
+        memory: "16Gi"
+        cpu: "4"
+
   deepseek-r1-qwen3-8b:
     name: "DeepSeek R1 Qwen3 8B"
     description: "All-in-one Ramalama server with embedded Unsloth DeepSeek-R1-0528-Qwen3-8B-UD-Q4_K_XL.gguf"

--- a/models/qwen3-30b-a3b-instruct-2507.conf
+++ b/models/qwen3-30b-a3b-instruct-2507.conf
@@ -1,0 +1,15 @@
+# Configuration for qwen3-30b-a3b-instruct-2507
+MODEL_NAME="qwen3-30b-a3b-instruct-2507"
+MODEL_DESCRIPTION="Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf from Unsloth"
+MODEL_GGUF_URL="hf://unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf"
+MODEL_SOURCE="qwen3-30b-a3b-instruct-2507-source"
+MODEL_FILE="/mnt/models/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf/Qwen3-30B-A3B-Instruct-2507-UD-Q4_K_XL.gguf"
+CTX_SIZE=16384
+THREADS=16
+TEMP=0.7
+TOP_K=20
+TOP_P=0.8
+CACHE_REUSE=256
+MAINTAINER="Kush Gupta"
+CREATE_LIGHTSPEED_OVERLAY=true
+LIGHTSPEED_NAMESPACE="ramalama"


### PR DESCRIPTION
## Summary by Sourcery

Add support for the new Qwen3-30B-A3B-Instruct-2507 model by registering it in the central models catalog, providing build and runtime configurations, and including Kubernetes overlays for both ramlama and OpenShift Lightspeed deployments.

New Features:
- Register Qwen3-30B-A3B-Instruct-2507 model in models.yaml with resource requests and inference parameters
- Provide a Containerfile for building the Qwen3-30B-A3B-Instruct-2507 model image
- Include a shell configuration file for the model’s default parameters and metadata
- Add kustomize manifests under k8s/models for deploying the new model in the ramlama namespace
- Create OpenShift Lightspeed overlays with OLSConfig, patched Secrets/Subscription, and a deployment README